### PR TITLE
Add working xcb config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Makefile
 run-tests.sh
 tests.pro
 /.qmake.stash
+tests/build-*
+*.pro.user*

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,16 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get -y --no-install-recomme
 	libx11-xcb-dev \
 	libxcb-glx0-dev \
 	libxkbcommon-x11-dev \
+	libxcb-shm0-dev \
+	libxcb-icccm4-dev \
+	libxcb-image0-dev \
+	libxcb-keysyms1-dev \
+	libxcb-render-util0-dev \
+	libxcb-xinerama0-dev \
+	x11proto-record-dev \
+	libxtst-dev \
+	libatspi2.0-dev \
+	libatk-bridge2.0-dev \
 	# bash needed for argument substitution in entrypoint
 	bash \
 	# since 5.14.0 we apparently need libdbus-1-dev and libnss3-dev

--- a/buildconfig/configure-5.15.0.sh
+++ b/buildconfig/configure-5.15.0.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 sed -i -e 's/"-lgds"/"-lfbclient"/' ../qtbase/src/plugins/sqldrivers/configure.json
-../configure -prefix $QT_PREFIX -opensource -confirm-license -nomake examples -nomake tests -skip qtwebengine
+../configure -prefix $QT_PREFIX -opensource -confirm-license -nomake examples -nomake tests -skip qtwebengine  -xcb -bundled-xcb-xinput

--- a/buildconfig/configure-5.15.1.sh
+++ b/buildconfig/configure-5.15.1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 sed -i -e 's/"-lgds"/"-lfbclient"/' ../qtbase/src/plugins/sqldrivers/configure.json
-../configure -prefix $QT_PREFIX -opensource -confirm-license -nomake examples -nomake tests -skip qtwebengine
+../configure -prefix $QT_PREFIX -opensource -confirm-license -nomake examples -nomake tests -skip qtwebengine -xcb -bundled-xcb-xinput

--- a/tests/xcb-plugin/main.cpp
+++ b/tests/xcb-plugin/main.cpp
@@ -2,7 +2,8 @@
 #include <QDir>
 //#define PLUGIN_DIR "plugindir"
 int main() {
-  QString platformDir = QString(PLUGIN_DIR) + "\\platforms";
+  QString platformDir = QString(PLUGIN_DIR) + "/platforms";
+  qDebug() << "searching plugin in directory " << platformDir;
   QDir pluginDir(platformDir);
   QStringList platformPlugins = pluginDir.entryList();
   qDebug() << "plugins found in file system: " << platformPlugins;

--- a/tests/xcb-plugin/main.cpp
+++ b/tests/xcb-plugin/main.cpp
@@ -1,0 +1,15 @@
+#include <QDebug>
+#include <QDir>
+//#define PLUGIN_DIR "plugindir"
+int main() {
+  QString platformDir = QString(PLUGIN_DIR) + "\\platforms";
+  QDir pluginDir(platformDir);
+  QStringList platformPlugins = pluginDir.entryList();
+  qDebug() << "plugins found in file system: " << platformPlugins;
+  if (platformPlugins.contains("libqxcb.so")) {
+	qDebug() << "xcb plugin found";
+	return 0;
+  }
+  qDebug() << "xcb plugin not found";
+  return 1;
+}

--- a/tests/xcb-plugin/xcb-plugin.pro
+++ b/tests/xcb-plugin/xcb-plugin.pro
@@ -1,0 +1,7 @@
+QT += core
+QT -= gui
+TARGET = xcb-plugin
+CONFIG   += console
+TEMPLATE = app
+SOURCES += main.cpp
+DEFINES += PLUGIN_DIR=\\\"$$[QT_INSTALL_PLUGINS]\\\"


### PR DESCRIPTION
Even though the `xcb` config flag was passed to `configure`, the xcb plugin was not installed. This adds a test to the build pipeline which checks for the presence of the xcb plugin after the build. This required some additional packages to satisfy the build configuration. Fixes #26 